### PR TITLE
add sentencepiece to README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ conda create -yn streaming python=3.8
 conda activate streaming
 
 pip install torch torchvision torchaudio
-pip install transformers accelerate datasets evaluate wandb scikit-learn scipy
+pip install transformers accelerate datasets evaluate wandb scikit-learn scipy sentencepiece
 
 python setup.py develop
 ```


### PR DESCRIPTION
Running the environment setup instructions gave me an error

```
CUDA_VISIBLE_DEVICES=0 python examples/run_streaming_llama.py  --enable_streaming                        [11:21:13]

Loading model from lmsys/vicuna-13b-v1.3 ...
....
    raise ValueError(
ValueError: Couldn't instantiate the backend tokenizer from one of:
(1) a `tokenizers` library serialization file,
(2) a slow tokenizer instance to convert or
(3) an equivalent slow tokenizer class to instantiate and convert.
You need to have sentencepiece installed to convert a slow tokenizer to a fast one.
```

Installing the sentencepiece tokenizer in the venv resolved it.