### PR TITLE
Convert demo video from MOV to MP4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ![schemes](figures/schemes.png)
 
 
-https://github.com/mit-han-lab/streaming-llm/assets/40906949/f0af8b59-d91a-4395-bf14-1bd9acbdfa87
-
+https://github.com/mit-han-lab/streaming-llm/assets/19784632/ce46825c-09f4-41ee-87e1-a492bc9f7f5e
 
 ## TL;DR
 We deploy LLMs for infinite-length inputs without sacrificing efficiency and performance.


### PR DESCRIPTION
Also switches encoding from HEVC to H.264

Fixes #9 

<img width="1249" alt="image" src="https://github.com/mit-han-lab/streaming-llm/assets/19784632/ffee2212-1544-450d-9cc6-1f0f233ed793">
