### PR TITLE
Streaming example: Move input_ids to model device rather than "cuda"

### DIFF
--- a/examples/run_streaming_llama.py
+++ b/examples/run_streaming_llama.py
@@ -64,7 +64,7 @@ def streaming_inference(model, tokenizer, prompts, kv_cache=None, max_gen_len=10
         prompt = "USER: " + prompt + "\n\nASSISTANT: "
         print("\n" + prompt, end="")
         input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-        input_ids = input_ids.to("cuda")
+        input_ids = input_ids.to(model.device)
         seq_len = input_ids.shape[1]
         if kv_cache is not None:
             space_needed = seq_len + max_gen_len


### PR DESCRIPTION
Closes #18

Hello!

## Pull Request overview
* Move `input_ids` to `model.device` rather than to `"cuda"`.

## Details
The model is placed on the right device automatically due to `device_map="auto"`, so we can just reuse the device from the model and it should work for everyone, regardless of whether they have CUDA, MPS or other hardware.

- Tom Aarsen