### PR TITLE
Enable explictly setting transformer model cache

### DIFF
--- a/examples/run_streaming_llama.py
+++ b/examples/run_streaming_llama.py
@@ -9,6 +9,7 @@ import os
 import time
 import re
 import sys
+os.environ['TRANSFORMERS_CACHE'] = "~/.cache/huggingface"  # path to llm cache
 
 from tqdm import tqdm
 from streaming_llm.utils import load, download_url, load_jsonl


### PR DESCRIPTION
Allow users to explicitly set where the downloaded transformer model (from Huggingface) should be saved. This is useful when the default `~/.cache` folder is linked to an unexpected path, e.g, when using a docker container.